### PR TITLE
Add linting and clean up typechecking and upgrade NextJS to fix a CVE

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "react/prop-types": "off",
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_"
+    }],
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["app/api/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ]
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     const { email, password } = result.data
 
     // Create response first
-    let response = NextResponse.next()
+    const response = NextResponse.next()
 
     // Create Supabase server client
     const supabase = createServerClient(

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -12,10 +12,10 @@ export async function POST(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -12,10 +12,10 @@ export async function GET(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -31,10 +31,10 @@ export async function POST(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -94,7 +94,7 @@ export async function POST(request: NextRequest) {
 
     // Supabase middleware will handle setting the session cookies
     return response
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/app/api/books/[id]/lane/route.ts
+++ b/app/api/books/[id]/lane/route.ts
@@ -23,10 +23,10 @@ export async function PATCH(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/books/[id]/route.ts
+++ b/app/api/books/[id]/route.ts
@@ -29,10 +29,10 @@ export async function GET(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -112,10 +112,10 @@ export async function PUT(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -215,10 +215,10 @@ export async function DELETE(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/books/[id]/status/route.ts
+++ b/app/api/books/[id]/status/route.ts
@@ -23,10 +23,10 @@ export async function PATCH(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/books/route.ts
+++ b/app/api/books/route.ts
@@ -23,10 +23,10 @@ export async function GET(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -94,10 +94,10 @@ export async function POST(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/books/search/route.ts
+++ b/app/api/books/search/route.ts
@@ -13,10 +13,10 @@ export async function GET(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/lanes/[id]/route.ts
+++ b/app/api/lanes/[id]/route.ts
@@ -26,10 +26,10 @@ export async function GET(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -93,10 +93,10 @@ export async function PUT(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -170,10 +170,10 @@ export async function DELETE(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/lanes/route.ts
+++ b/app/api/lanes/route.ts
@@ -18,10 +18,10 @@ export async function GET(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -73,10 +73,10 @@ export async function POST(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/swimlanes/[id]/route.ts
+++ b/app/api/swimlanes/[id]/route.ts
@@ -24,10 +24,10 @@ export async function GET(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -91,10 +91,10 @@ export async function PUT(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -168,10 +168,10 @@ export async function DELETE(
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/api/swimlanes/route.ts
+++ b/app/api/swimlanes/route.ts
@@ -19,10 +19,10 @@ export async function GET(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },
@@ -74,10 +74,10 @@ export async function POST(request: NextRequest) {
           get(name: string) {
             return request.cookies.get(name)?.value
           },
-          set(name: string, value: string, options: any) {
+          set(_name: string, _value: string, _options: any) {
             // This is handled by the middleware
           },
-          remove(name: string, options: any) {
+          remove(_name: string, _options: any) {
             // This is handled by the middleware
           },
         },

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { createBrowserClient } from '@supabase/ssr'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../components/ui/card'
 import { Button } from '../../../components/ui/button'
 import { useToast } from '../../../hooks/use-toast'
 
-export default function AuthCallback() {
+function AuthCallbackContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { toast } = useToast()
@@ -139,4 +139,30 @@ export default function AuthCallback() {
   }
 
   return null
+}
+
+function AuthCallbackLoading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle className="text-center">ReadingRoadmap</CardTitle>
+          <CardDescription className="text-center">
+            Loading...
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default function AuthCallback() {
+  return (
+    <Suspense fallback={<AuthCallbackLoading />}>
+      <AuthCallbackContent />
+    </Suspense>
+  )
 } 

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -79,7 +79,7 @@ function AuthForm() {
         })
         router.push('/')
       }
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "An error occurred during login",
@@ -126,7 +126,7 @@ function AuthForm() {
           router.push('/')
         }
       }
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "An error occurred during registration",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react'
 import { useQuery } from "@tanstack/react-query"
 import { ReadingBoard } from "../components/reading-board"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card"
+import { Card, CardContent } from "../components/ui/card"
 import { Skeleton } from "../components/ui/skeleton"
 import { Button } from "../components/ui/button"
 import { BookSearch } from "../components/book-search"
@@ -30,7 +30,7 @@ export default function HomePage() {
           setUser(null)
           setIsAuthenticated(false)
         }
-      } catch (error) {
+      } catch {
         setUser(null)
         setIsAuthenticated(false)
       }
@@ -96,7 +96,7 @@ export default function HomePage() {
                   <BookOpen className="h-8 w-8 mx-auto mb-3 text-blue-600" />
                   <h3 className="font-semibold mb-2">Track Your Reading</h3>
                   <p className="text-sm text-muted-foreground">
-                    Keep track of what you're reading and your progress
+                    Keep track of what you&apos;re reading and your progress
                   </p>
                 </CardContent>
               </Card>
@@ -266,7 +266,7 @@ export default function HomePage() {
           <header className="space-y-2">
             <h1 className="text-4xl font-bold tracking-tight">Reading Roadmap</h1>
             <p className="text-muted-foreground">
-              Welcome back{user?.email ? `, ${user.email.split('@')[0]}` : ''}! Here's your reading journey
+              Welcome back{user?.email ? `, ${user.email.split('@')[0]}` : ''}! Here&apos;s your reading journey
             </p>
           </header>
 

--- a/components/book-card.tsx
+++ b/components/book-card.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
 import { Slider } from "@/components/ui/slider";
 import { formatReadingTime, formatProgress } from "@/lib/utils";
 import { apiRequest } from "@/lib/queryClient";

--- a/components/book-search.tsx
+++ b/components/book-search.tsx
@@ -48,7 +48,7 @@ export function BookSearch() {
       try {
         const response = await fetch('/api/auth/me');
         setIsAuthenticated(response.ok);
-      } catch (error) {
+      } catch {
         setIsAuthenticated(false);
       }
     };
@@ -108,8 +108,8 @@ export function BookSearch() {
         // Ensure openLibraryBooks is an array
         openLibraryBooks = Array.isArray(openLibraryBooks) ? openLibraryBooks : [];
         console.log('🌐 Open Library books found:', openLibraryBooks.length);
-      } catch (error) {
-        console.error('❌ Open Library search failed:', error);
+      } catch (err) {
+        console.error('❌ Open Library search failed:', err);
         openLibraryBooks = [];
       }
 
@@ -144,8 +144,8 @@ export function BookSearch() {
 
       console.log('✅ Final combined results:', combinedResults.length);
       setResults(combinedResults);
-    } catch (error) {
-      console.error("❌ Error searching books:", error);
+    } catch (err) {
+      console.error("❌ Error searching books:", err);
       setResults([]);
     } finally {
       setIsSearching(false);

--- a/components/nav-header.tsx
+++ b/components/nav-header.tsx
@@ -29,7 +29,7 @@ export function NavHeader() {
         } else {
           setUser(null);
         }
-      } catch (error) {
+      } catch {
         setUser(null);
       } finally {
         setIsLoading(false);
@@ -43,8 +43,8 @@ export function NavHeader() {
       await fetch('/api/auth/logout', { method: 'POST' });
       setUser(null);
       router.push('/');
-    } catch (error) {
-      console.error('Logout error:', error);
+    } catch (err) {
+      console.error('Logout error:', err);
     }
   };
 

--- a/components/reading-board.tsx
+++ b/components/reading-board.tsx
@@ -1,5 +1,5 @@
-import { DragDropContext, Droppable, Draggable } from "@hello-pangea/dnd";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { BookCard } from "./book-card";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
@@ -75,7 +75,7 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
     }
   });
 
-  const onDragEnd = (result: any) => {
+  const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
 
     const bookId = parseInt(result.draggableId);

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -52,8 +52,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -6,20 +6,21 @@ export const supabase = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 )
 
-// Server-side Supabase client (for API routes)
+// Server-side Supabase client (for API routes) - read-only cookie access
 export function createServerSupabaseClient(request: Request) {
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return request.headers.get('cookie')?.split(';').find(c => c.trim().startsWith(`${name}=`))?.split('=')[1]
+        getAll() {
+          const cookieHeader = request.headers.get('cookie') || ''
+          return cookieHeader.split(';').map(c => {
+            const [name, ...rest] = c.trim().split('=')
+            return { name, value: rest.join('=') }
+          }).filter(c => c.name)
         },
-        set(name: string, value: string, options: any) {
-          // This is handled by the middleware
-        },
-        remove(name: string, options: any) {
+        setAll() {
           // This is handled by the middleware
         },
       },

--- a/next.config.js
+++ b/next.config.js
@@ -10,10 +10,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
-  experimental: {
-    // Ensure compatibility with Vercel
-    serverComponentsExternalPackages: [],
-  },
+  serverExternalPackages: [],
 }
 
 export default nextConfig 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "framer-motion": "^11.13.1",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.453.0",
-        "next": "^15.3.3",
+        "next": "^15.3.8",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.3.tgz",
-      "integrity": "sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.8.tgz",
+      "integrity": "sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2289,9 +2289,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.3.tgz",
-      "integrity": "sha512-WRJERLuH+O3oYB4yZNVahSVFmtxRNjNF1I1c34tYMoJb0Pve+7/RaLAJJizyYiFhjYNGHRAE1Ri2Fd23zgDqhg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
+      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
       "cpu": [
         "arm64"
       ],
@@ -2305,9 +2305,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.3.tgz",
-      "integrity": "sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
+      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
       "cpu": [
         "x64"
       ],
@@ -2321,9 +2321,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.3.tgz",
-      "integrity": "sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
+      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
       "cpu": [
         "arm64"
       ],
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.3.tgz",
-      "integrity": "sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
+      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
       "cpu": [
         "arm64"
       ],
@@ -2353,9 +2353,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.3.tgz",
-      "integrity": "sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
+      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
       "cpu": [
         "x64"
       ],
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.3.tgz",
-      "integrity": "sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
+      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
       "cpu": [
         "x64"
       ],
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.3.tgz",
-      "integrity": "sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
+      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
       "cpu": [
         "arm64"
       ],
@@ -2401,9 +2401,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.3.tgz",
-      "integrity": "sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
+      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
       "cpu": [
         "x64"
       ],
@@ -7364,21 +7364,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bufferutil": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -12893,12 +12878,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.3.tgz",
-      "integrity": "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.8.tgz",
+      "integrity": "sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.3",
+        "@next/env": "15.3.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -12913,14 +12898,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.3",
-        "@next/swc-darwin-x64": "15.3.3",
-        "@next/swc-linux-arm64-gnu": "15.3.3",
-        "@next/swc-linux-arm64-musl": "15.3.3",
-        "@next/swc-linux-x64-gnu": "15.3.3",
-        "@next/swc-linux-x64-musl": "15.3.3",
-        "@next/swc-win32-arm64-msvc": "15.3.3",
-        "@next/swc-win32-x64-msvc": "15.3.3",
+        "@next/swc-darwin-arm64": "15.3.5",
+        "@next/swc-darwin-x64": "15.3.5",
+        "@next/swc-linux-arm64-gnu": "15.3.5",
+        "@next/swc-linux-arm64-musl": "15.3.5",
+        "@next/swc-linux-x64-gnu": "15.3.5",
+        "@next/swc-linux-x64-musl": "15.3.5",
+        "@next/swc-win32-arm64-msvc": "15.3.5",
+        "@next/swc-win32-x64-msvc": "15.3.5",
         "sharp": "^0.34.1"
       },
       "peerDependencies": {
@@ -13018,19 +13003,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.3.tgz",
-      "integrity": "sha512-EMS95CMJzdoSKoIiXo8pxKoL8DYxwIZXYlLmgPb8KUv794abpnLK6ynsCAWNliOjREKruYKdzbh76HHYUHX7nw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "framer-motion": "^11.13.1",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.453.0",
-    "next": "^15.3.3",
+    "next": "^15.3.8",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces project-wide linting and type safety improvements, modest auth UX refinements, and framework upgrades.
> 
> - **Add `.eslintrc.json`** with Next + TS presets; enforce unused-var rules and relax `any` only for `app/api/**`.
> - **Type fixes/refactors**: replace `any` with explicit types (e.g., `DropResult`), convert some interfaces to `type` aliases, tighten component props and icon components, escape apostrophes, and remove unused imports.
> - **Auth flow**: refactor `app/auth/callback` to use `Suspense` with a dedicated loading fallback; simplify error handling in auth pages; minor copy tweaks.
> - **Supabase cookie handling**: introduce read-only `getAll`/`setAll` in `lib/supabase` and align API route cookie handlers (underscore unused args).
> - **UI/Pages cleanup**: minor UI polish and safer fetch/auth checks across header, home, and search; no functional API changes to data.
> - **Upgrade**: bump `next` to `15.3.8`, update SWC binaries in lockfile, and adjust `next.config.js` (`serverExternalPackages`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e707e9a18ad4bd5a86f790cb7aaf0f630fc451e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->