### PR TITLE
Improve mobile layout and reduce duplicate component logic

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,14 @@ import React from 'react'
 import './globals.css'
 import { Inter } from 'next/font/google'
 import { Providers } from '../components/providers'
+import type { Viewport } from 'next'
 
 const inter = Inter({ subsets: ['latin'] })
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+}
 
 export const metadata = {
   title: 'ReadingRoadmap',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,9 +82,9 @@ export default function HomePage() {
           <div className="max-w-7xl mx-auto space-y-8">
             <Skeleton className="h-12 w-64" />
             <Skeleton className="h-4 w-96" />
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
               {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-32" />
+                <Skeleton key={i} className="h-24 sm:h-32" />
               ))}
             </div>
           </div>
@@ -106,8 +106,8 @@ export default function HomePage() {
                   <BookMarked className="h-16 w-16 text-primary" />
                 </div>
               </div>
-              <h1 className="text-4xl font-bold tracking-tight">Welcome to Reading Roadmap</h1>
-              <p className="text-xl text-muted-foreground">
+              <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">Welcome to Reading Roadmap</h1>
+              <p className="text-base sm:text-xl text-muted-foreground">
                 Organize your reading journey, track your progress, and discover new books
               </p>
             </div>
@@ -215,48 +215,48 @@ export default function HomePage() {
         )}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
         <Card className="bg-blue-50 dark:bg-blue-950/30">
-          <CardContent className="p-6 flex flex-col">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium">Total Books</h3>
-              <Library className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <CardContent className="p-3 sm:p-6 flex flex-col">
+            <div className="flex items-center justify-between mb-2 sm:mb-4">
+              <h3 className="text-sm sm:text-lg font-medium">Total Books</h3>
+              <Library className="h-4 w-4 sm:h-5 sm:w-5 text-blue-600 dark:text-blue-400" />
             </div>
-            <p className="text-3xl font-bold">{totalBooks}</p>
-            <p className="text-sm text-muted-foreground mt-2">Books in your library</p>
+            <p className="text-2xl sm:text-3xl font-bold">{totalBooks}</p>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-1 sm:mt-2">In your library</p>
           </CardContent>
         </Card>
-        
+
         <Card className="bg-amber-50 dark:bg-amber-950/30">
-          <CardContent className="p-6 flex flex-col">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium">To Read</h3>
-              <ListTodo className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+          <CardContent className="p-3 sm:p-6 flex flex-col">
+            <div className="flex items-center justify-between mb-2 sm:mb-4">
+              <h3 className="text-sm sm:text-lg font-medium">To Read</h3>
+              <ListTodo className="h-4 w-4 sm:h-5 sm:w-5 text-amber-600 dark:text-amber-400" />
             </div>
-            <p className="text-3xl font-bold">{toReadCount}</p>
-            <p className="text-sm text-muted-foreground mt-2">Books to read</p>
+            <p className="text-2xl sm:text-3xl font-bold">{toReadCount}</p>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-1 sm:mt-2">Books to read</p>
           </CardContent>
         </Card>
-        
+
         <Card className="bg-green-50 dark:bg-green-950/30">
-          <CardContent className="p-6 flex flex-col">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium">In Progress</h3>
-              <BookOpen className="h-5 w-5 text-green-600 dark:text-green-400" />
+          <CardContent className="p-3 sm:p-6 flex flex-col">
+            <div className="flex items-center justify-between mb-2 sm:mb-4">
+              <h3 className="text-sm sm:text-lg font-medium">In Progress</h3>
+              <BookOpen className="h-4 w-4 sm:h-5 sm:w-5 text-green-600 dark:text-green-400" />
             </div>
-            <p className="text-3xl font-bold">{inProgressCount}</p>
-            <p className="text-sm text-muted-foreground mt-2">Currently reading</p>
+            <p className="text-2xl sm:text-3xl font-bold">{inProgressCount}</p>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-1 sm:mt-2">Currently reading</p>
           </CardContent>
         </Card>
-        
+
         <Card className="bg-purple-50 dark:bg-purple-950/30">
-          <CardContent className="p-6 flex flex-col">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-medium">Completed</h3>
-              <TrendingUp className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+          <CardContent className="p-3 sm:p-6 flex flex-col">
+            <div className="flex items-center justify-between mb-2 sm:mb-4">
+              <h3 className="text-sm sm:text-lg font-medium">Completed</h3>
+              <TrendingUp className="h-4 w-4 sm:h-5 sm:w-5 text-purple-600 dark:text-purple-400" />
             </div>
-            <p className="text-3xl font-bold">{completedCount}</p>
-            <p className="text-sm text-muted-foreground mt-2">Books finished</p>
+            <p className="text-2xl sm:text-3xl font-bold">{completedCount}</p>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-1 sm:mt-2">Books finished</p>
           </CardContent>
         </Card>
       </div>
@@ -288,10 +288,10 @@ export default function HomePage() {
           </div>
         ) : (
           <Card>
-            <CardContent className="p-8 text-center">
-              <BookIcon className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-              <h3 className="text-lg font-semibold mb-2">No books yet</h3>
-              <p className="text-muted-foreground mb-4">
+            <CardContent className="p-6 sm:p-8 text-center">
+              <BookIcon className="h-10 w-10 sm:h-12 sm:w-12 mx-auto mb-3 sm:mb-4 text-muted-foreground" />
+              <h3 className="text-base sm:text-lg font-semibold mb-2">No books yet</h3>
+              <p className="text-sm sm:text-base text-muted-foreground mb-4">
                 Start building your reading roadmap by adding your first book
               </p>
               <BookSearch />
@@ -329,9 +329,9 @@ export default function HomePage() {
       <NavHeader />
       <main className="flex-1 p-4 md:p-8">
         <div className="max-w-7xl mx-auto space-y-8">
-          <header className="space-y-2">
-            <h1 className="text-4xl font-bold tracking-tight">Reading Roadmap</h1>
-            <p className="text-muted-foreground">
+          <header className="space-y-1 sm:space-y-2">
+            <h1 className="text-2xl sm:text-4xl font-bold tracking-tight">Reading Roadmap</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">
               Welcome back{user?.email ? `, ${user.email.split('@')[0]}` : ''}! Here&apos;s your reading journey
             </p>
           </header>
@@ -354,11 +354,9 @@ export default function HomePage() {
           {activeTab === "dashboard" ? (
             renderDashboard()
           ) : (
-            <Card>
-              <CardContent className="p-6">
-                <ReadingBoard books={books || []} userLanes={userLanes || []} />
-              </CardContent>
-            </Card>
+            <div className="sm:rounded-lg sm:border sm:bg-card sm:p-6">
+              <ReadingBoard books={books || []} userLanes={userLanes || []} />
+            </div>
           )}
         </div>
       </main>

--- a/components/book-card.tsx
+++ b/components/book-card.tsx
@@ -37,77 +37,46 @@ export function BookCard({ book, onTap }: BookCardProps) {
       className={`overflow-hidden ${onTap ? 'cursor-pointer active:scale-[0.98] transition-transform' : ''}`}
       onClick={handleCardClick}
     >
-      {/* Mobile: horizontal layout */}
-      <div className="flex sm:hidden p-3 gap-3">
+      {/* Mobile: horizontal flex row; Desktop: vertical stack */}
+      <div className="flex sm:flex-col">
         <img
           src={book.coverUrl}
           alt={book.title}
-          className="w-16 h-24 object-cover rounded flex-shrink-0"
+          className="w-16 h-24 object-cover rounded flex-shrink-0 m-3 sm:m-0 sm:w-full sm:h-auto sm:aspect-[3/4] sm:rounded-none"
         />
-        <div className="flex-1 min-w-0 flex flex-col justify-between">
+        <CardContent className="flex-1 min-w-0 flex flex-col justify-between p-3 pl-0 sm:p-4">
           <div>
-            <h4 className="font-semibold leading-tight text-sm line-clamp-2">{book.title}</h4>
-            <p className="text-xs text-muted-foreground truncate">{book.author}</p>
+            <h4 className="font-semibold leading-tight text-sm sm:text-base line-clamp-2">{book.title}</h4>
+            <p className="text-xs sm:text-sm text-muted-foreground truncate">{book.author}</p>
           </div>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">
-              {formatReadingTime(book.estimatedMinutes)}
-            </p>
-            {book.status === "reading" && (
-              <div className="flex items-center gap-2">
-                <Slider
-                  value={[readingProgress]}
-                  min={0}
-                  max={100}
-                  step={1}
-                  onValueChange={([value]) => updateProgressMutation.mutate(value)}
-                  className="flex-1"
-                />
-                <span className="text-xs text-muted-foreground w-8">
-                  {formatProgress(readingProgress)}
-                </span>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Desktop: vertical layout */}
-      <div className="hidden sm:block">
-        <div className="aspect-[3/4] relative">
-          <img
-            src={book.coverUrl}
-            alt={book.title}
-            className="absolute inset-0 w-full h-full object-cover"
-          />
-        </div>
-        <CardContent className="p-4 space-y-4">
-          <div>
-            <h4 className="font-semibold leading-tight text-base">{book.title}</h4>
-            <p className="text-sm text-muted-foreground">{book.author}</p>
-          </div>
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span>Reading Time</span>
+          <div className="space-y-1 sm:space-y-2 mt-1 sm:mt-2">
+            <div className="sm:flex sm:justify-between text-xs sm:text-sm">
+              <span className="hidden sm:inline">Reading Time</span>
               <span className="text-muted-foreground">
                 {formatReadingTime(book.estimatedMinutes)}
               </span>
             </div>
             {book.status === "reading" && (
-              <div className="space-y-2">
-                <div className="flex justify-between text-sm">
+              <div className="space-y-1 sm:space-y-2">
+                <div className="hidden sm:flex justify-between text-sm">
                   <span>Progress</span>
                   <span className="text-muted-foreground">
                     {formatProgress(readingProgress)}
                   </span>
                 </div>
-                <Slider
-                  value={[readingProgress]}
-                  min={0}
-                  max={100}
-                  step={1}
-                  onValueChange={([value]) => updateProgressMutation.mutate(value)}
-                />
+                <div className="flex items-center gap-2 sm:block">
+                  <Slider
+                    value={[readingProgress]}
+                    min={0}
+                    max={100}
+                    step={1}
+                    onValueChange={([value]) => updateProgressMutation.mutate(value)}
+                    className="flex-1"
+                  />
+                  <span className="text-xs text-muted-foreground w-8 sm:hidden">
+                    {formatProgress(readingProgress)}
+                  </span>
+                </div>
               </div>
             )}
           </div>

--- a/components/book-search.tsx
+++ b/components/book-search.tsx
@@ -187,12 +187,12 @@ export function BookSearch() {
           Add Book
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-2xl" onOpenAutoFocus={(e) => e.preventDefault()}>
-        <DialogHeader>
+      <DialogContent className="sm:max-w-2xl flex flex-col overflow-hidden" onOpenAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader className="flex-shrink-0">
           <DialogTitle>Search Books</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="relative">
+        <div className="flex flex-col flex-1 min-h-0 gap-4">
+          <div className="relative flex-shrink-0">
             <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder="Search by title or author..."
@@ -201,7 +201,7 @@ export function BookSearch() {
               onChange={(e) => setQuery(e.target.value)}
             />
           </div>
-          <div className="space-y-3 max-h-[50vh] sm:max-h-[400px] overflow-y-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+          <div className="space-y-3 flex-1 min-h-0 overflow-y-auto -mx-4 px-4 sm:mx-0 sm:px-0">
             {isSearching ? (
               <div className="space-y-3">
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/components/book-search.tsx
+++ b/components/book-search.tsx
@@ -187,7 +187,7 @@ export function BookSearch() {
           Add Book
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-2xl sm:w-[95vw]">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Search Books</DialogTitle>
         </DialogHeader>

--- a/components/book-search.tsx
+++ b/components/book-search.tsx
@@ -187,7 +187,7 @@ export function BookSearch() {
           Add Book
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="sm:max-w-2xl" onOpenAutoFocus={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>Search Books</DialogTitle>
         </DialogHeader>

--- a/components/reading-board.tsx
+++ b/components/reading-board.tsx
@@ -206,7 +206,7 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
     <div className="space-y-6">
       {/* Create User Lane */}
       <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">Reading Board</h2>
+        <h2 className="text-xl sm:text-2xl font-bold">Reading Board</h2>
         <Dialog open={createLaneOpen} onOpenChange={setCreateLaneOpen}>
           <DialogTrigger asChild>
             <Button variant="outline" size="sm" className="cursor-pointer">
@@ -242,14 +242,14 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
       </div>
 
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0 snap-x snap-mandatory md:grid md:grid-cols-3 md:gap-6 md:overflow-visible md:pb-0">
           {/* To Read Column */}
-          <div className="space-y-4">
+          <div className="min-w-[280px] flex-shrink-0 snap-start space-y-3 sm:space-y-4 md:min-w-0 md:flex-shrink">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold">To Read</h3>
+              <h3 className="text-base sm:text-lg font-semibold">To Read</h3>
               <BookSearch />
             </div>
-            <div className="space-y-4 min-h-[200px] p-4 bg-muted/20 rounded-lg">
+            <div className="space-y-3 sm:space-y-4 min-h-[200px] p-3 sm:p-4 bg-muted/20 rounded-lg">
               {Array.from(toReadByLane.entries()).map(([laneId]) =>
                 renderLaneSection(laneId, "to-read", toReadBooks)
               )}
@@ -257,9 +257,9 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
           </div>
 
           {/* In Progress Column */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">In Progress</h3>
-            <div className="space-y-4 min-h-[200px] p-4 bg-muted/20 rounded-lg">
+          <div className="min-w-[280px] flex-shrink-0 snap-start space-y-3 sm:space-y-4 md:min-w-0 md:flex-shrink">
+            <h3 className="text-base sm:text-lg font-semibold">In Progress</h3>
+            <div className="space-y-3 sm:space-y-4 min-h-[200px] p-3 sm:p-4 bg-muted/20 rounded-lg">
               {Array.from(inProgressByLane.entries()).map(([laneId]) =>
                 renderLaneSection(laneId, "reading", inProgressBooks)
               )}
@@ -267,9 +267,9 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
           </div>
 
           {/* Completed Column */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">Completed</h3>
-            <div className="space-y-4 min-h-[200px] p-4 bg-muted/20 rounded-lg">
+          <div className="min-w-[280px] flex-shrink-0 snap-start space-y-3 sm:space-y-4 md:min-w-0 md:flex-shrink">
+            <h3 className="text-base sm:text-lg font-semibold">Completed</h3>
+            <div className="space-y-3 sm:space-y-4 min-h-[200px] p-3 sm:p-4 bg-muted/20 rounded-lg">
               {Array.from(completedByLane.entries()).map(([laneId]) =>
                 renderLaneSection(laneId, "completed", completedBooks)
               )}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-0 right-0 bottom-0 z-50 grid w-full max-w-lg mx-auto gap-4 border bg-background p-4 pb-8 sm:p-6 shadow-lg duration-200 max-h-[85vh] overflow-y-auto rounded-t-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-h-[90vh] sm:pb-6",
+        "fixed left-0 right-0 bottom-0 z-50 grid w-full max-w-lg mx-auto gap-4 border bg-background p-4 pb-8 sm:p-6 shadow-lg duration-200 max-h-[85dvh] overflow-y-auto rounded-t-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-h-[90dvh] sm:pb-6",
         className
       )}
       {...props}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-0 right-0 bottom-0 z-50 grid w-full max-w-lg mx-auto gap-4 border bg-background p-4 pb-8 sm:p-6 shadow-lg duration-200 max-h-[85vh] overflow-y-auto rounded-t-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-h-[90vh] sm:pb-6",
         className
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-0 right-0 bottom-0 z-50 grid w-full max-w-lg mx-auto gap-4 border bg-background p-4 pb-8 sm:p-6 shadow-lg duration-200 max-h-[85vh] overflow-y-auto rounded-t-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-h-[90vh] sm:pb-6",
+        "fixed left-0 right-0 bottom-0 z-50 grid w-full max-w-lg mx-auto gap-4 border bg-background p-4 pb-8 sm:p-6 shadow-lg duration-200 max-h-[85dvh] overflow-y-auto rounded-t-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:left-[50%] sm:top-[50%] sm:bottom-auto sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-h-[90dvh] sm:pb-6",
         className
       )}
       {...props}


### PR DESCRIPTION
- Unify BookCard into single responsive layout (was two separate
  mobile/desktop render trees with duplicated markup)
- Make AlertDialog use the same mobile bottom-sheet pattern as Dialog
  (slides up from bottom on mobile, centered on desktop)
- Dashboard stats grid: 2-col on mobile with compact padding/text
- Reading board: horizontal scroll with snap on mobile instead of
  stacked columns, tighter spacing
- Remove Card wrapper around ReadingBoard on mobile to save space
- Scale down headings and empty states for mobile viewports
- Fix BookSearch dialog sizing class

https://claude.ai/code/session_01HnAsR6adYYH5xVmw6mUTxQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily styling/responsiveness changes with small component refactors; risk is limited to potential layout/scroll regressions on mobile and modal behavior.
> 
> **Overview**
> Improves mobile UX across the app by tightening typography/padding, switching key grids to 2-column layouts on small screens, and refining empty/loading states.
> 
> Refactors `BookCard` to a single responsive render tree (removing separate mobile/desktop markup) and updates the Reading Board to use a horizontally scrollable, snap-aligned column layout on mobile while keeping the 3-column grid on desktop.
> 
> Aligns modal behavior by making `AlertDialog` use the same mobile bottom-sheet presentation as `Dialog` (and updates both to use `dvh`), fixes `BookSearch` dialog sizing/scroll behavior, and adds a Next.js `viewport` export in `app/layout.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd0b25f16b35bca51b2b8c65222d340139418dad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->