### PR TITLE
Add book deletion functionality with confirmation dialog

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { NavHeader } from "../components/nav-header"
 import { GoalCard } from "../components/goal-card"
 import { GoalForm } from "../components/goal-form"
 import { Book as BookIcon, BookOpen, ListTodo, PanelRight, Library, TrendingUp, ArrowRight, BookMarked, Plus, Target } from "lucide-react"
+import { useToast } from "@/hooks/use-toast"
 import type { Book, UserLane, ReadingGoal } from "../shared/schema"
 import { apiRequest } from "../lib/queryClient"
 import { useRouter } from "next/navigation"
@@ -64,6 +65,7 @@ export default function HomePage() {
   const [selectedBook, setSelectedBook] = useState<Book | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const queryClient = useQueryClient()
+  const { toast } = useToast()
   const isLoading = isAuthenticated === null || (isAuthenticated && (booksLoading || lanesLoading || goalsLoading))
 
   const updateBookStatusMutation = useMutation({
@@ -84,6 +86,16 @@ export default function HomePage() {
     }
   });
 
+  const deleteBookMutation = useMutation({
+    mutationFn: async (bookId: number) => {
+      await apiRequest("DELETE", `/api/books/${bookId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/books"] });
+      toast({ title: "Book removed" });
+    }
+  });
+
   const handleBookTap = (book: Book) => {
     setSelectedBook(book);
     setDrawerOpen(true);
@@ -95,6 +107,10 @@ export default function HomePage() {
 
   const handleLaneChange = (bookId: number, laneId: number | null) => {
     updateBookLaneMutation.mutate({ bookId, laneId });
+  };
+
+  const handleDelete = (bookId: number) => {
+    deleteBookMutation.mutate(bookId);
   };
 
   const handleEditGoal = (goal: ReadingGoal) => {
@@ -414,6 +430,7 @@ export default function HomePage() {
         onOpenChange={setDrawerOpen}
         onStatusChange={handleStatusChange}
         onLaneChange={handleLaneChange}
+        onDelete={handleDelete}
       />
     </div>
   )

--- a/components/book-action-drawer.tsx
+++ b/components/book-action-drawer.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -7,9 +8,19 @@ import {
   DrawerTitle,
   DrawerDescription,
 } from "@/components/ui/drawer";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { BookOpen, CheckCircle2, ListTodo, FolderOpen, Check } from "lucide-react";
+import { BookOpen, CheckCircle2, ListTodo, FolderOpen, Check, Trash2 } from "lucide-react";
 import type { Book, UserLane } from "@shared/schema";
 
 interface BookActionDrawerProps {
@@ -19,6 +30,7 @@ interface BookActionDrawerProps {
   onOpenChange: (open: boolean) => void;
   onStatusChange: (bookId: number, status: string) => void;
   onLaneChange: (bookId: number, laneId: number | null) => void;
+  onDelete?: (bookId: number) => void;
 }
 
 const statusOptions = [
@@ -34,7 +46,10 @@ export function BookActionDrawer({
   onOpenChange,
   onStatusChange,
   onLaneChange,
+  onDelete,
 }: BookActionDrawerProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
   if (!book) return null;
 
   const handleStatusChange = (status: string) => {
@@ -44,6 +59,12 @@ export function BookActionDrawer({
 
   const handleLaneChange = (laneId: number | null) => {
     onLaneChange(book.id, laneId);
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    onDelete?.(book.id);
+    setConfirmDeleteOpen(false);
     onOpenChange(false);
   };
 
@@ -143,8 +164,44 @@ export function BookActionDrawer({
               Currently in: <span className="font-medium">{getLaneName(book.laneId)}</span>
             </p>
           </div>
+
+          {/* Delete Section */}
+          {onDelete && (
+            <>
+              <Separator />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full text-destructive hover:text-destructive hover:bg-destructive/10 cursor-pointer"
+                onClick={() => setConfirmDeleteOpen(true)}
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Remove Book
+              </Button>
+            </>
+          )}
         </div>
       </DrawerContent>
+
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove book</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove &ldquo;{book.title}&rdquo; from your collection? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 cursor-pointer"
+              onClick={handleDelete}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Drawer>
   );
 }

--- a/components/reading-board.tsx
+++ b/components/reading-board.tsx
@@ -48,6 +48,16 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
     }
   });
 
+  const deleteBookMutation = useMutation({
+    mutationFn: async (bookId: number) => {
+      await apiRequest("DELETE", `/api/books/${bookId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/books"] });
+      toast({ title: "Book removed" });
+    }
+  });
+
   const createLaneSchema = z.object({
     name: z.string().min(1),
     order: z.number(),
@@ -202,6 +212,10 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
     updateBookLaneMutation.mutate({ bookId, laneId });
   };
 
+  const handleDelete = (bookId: number) => {
+    deleteBookMutation.mutate(bookId);
+  };
+
   return (
     <div className="space-y-6">
       {/* Create User Lane */}
@@ -286,6 +300,7 @@ export function ReadingBoard({ books, userLanes }: ReadingBoardProps) {
         onOpenChange={setDrawerOpen}
         onStatusChange={handleStatusChange}
         onLaneChange={handleLaneChange}
+        onDelete={handleDelete}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
This PR adds the ability for users to delete books from their collection with a confirmation dialog to prevent accidental removals.

## Key Changes
- **BookActionDrawer component**: Added delete button with trash icon in the action drawer, integrated with a confirmation alert dialog
- **Delete confirmation**: Implemented AlertDialog component to confirm book deletion before proceeding
- **API integration**: Added `DELETE /api/books/{bookId}` mutation in both `HomePage` and `ReadingBoard` components
- **User feedback**: Added toast notification when a book is successfully removed
- **Optional callback**: Made `onDelete` prop optional in BookActionDrawer to maintain backward compatibility
- **State management**: Added `confirmDeleteOpen` state to manage the confirmation dialog visibility

## Implementation Details
- The delete button only appears when the `onDelete` callback is provided
- Confirmation dialog displays the book title to clarify which book will be removed
- After deletion, the drawer closes and the books query is invalidated to refresh the UI
- The implementation is consistent across both the main page and reading board views
- Destructive styling applied to delete button and confirmation action for visual clarity

https://claude.ai/code/session_01Wfnop8ZACUdWVZ9DoqB2An