### PR TITLE
Fix Recently Added showing books in wrong order

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -322,7 +322,7 @@ export default function HomePage() {
         
         {books && books.length > 0 ? (
           <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
-            {books.slice(-4).reverse().map(book => (
+            {books.slice(0, 4).map(book => (
               <Card
                 key={book.id}
                 className="overflow-hidden cursor-pointer active:scale-[0.98] transition-transform"


### PR DESCRIPTION
## Summary
- `slice(-4).reverse()` was fighting against the API's `order('added_at', { ascending: false })`, resulting in the 4 oldest books showing newest-first instead of the 4 newest
- Fixed to `slice(0, 4)` since the API already returns books in the correct order

## Test plan
- [ ] Add a few books and verify the 4 most recently added appear in the Dashboard's "Recently Added" section, newest first